### PR TITLE
chore: replace slatify by notify-on-failure

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -100,20 +100,11 @@ jobs:
           path: ./dist
 
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "Build :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 
   audit-licenses:
     runs-on: ubuntu-latest
@@ -145,20 +136,11 @@ jobs:
         run: npm run audit:licences
 
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "License audit :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 
   vulnerability-scan:
     runs-on: ubuntu-latest
@@ -186,20 +168,11 @@ jobs:
           sarif_file: "trivy-results.sarif"
 
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "Vulnerability scan :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 
   deploy:
     environment:
@@ -221,17 +194,7 @@ jobs:
         uses: actions/deploy-pages@v2
 
       - name: Send status to Slack
-        # Third-party action, pin to commit SHA!
-        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-        uses: lazy-actions/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65 # == v3.0.0
-        if: ${{ failure() && env.SLACK_WEBHOOK_URL }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() }}
         with:
-          type: ${{ job.status }}
-          job_name: "Deploy to GitHub Pages :point_right:"
-          mention: "here"
-          mention_if: "failure"
-          commit: true
-          url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Since [slatify](https://github.com/lazy-actions/slatify/) isn't maintained anymore, we're replacing it [notify-on-failure](https://github.com/digitalservicebund/notify-on-failure-gha).
All you have to do is review this PR, merge it, and let Platform know if you run into any issue.

More details [available here](https://platform-docs.prod.ds4g.net/user-docs/how-to-guides/ci-cd/slack-integration).
